### PR TITLE
Add serialization for `Light` structure

### DIFF
--- a/src/hue.rs
+++ b/src/hue.rs
@@ -67,7 +67,7 @@ pub struct LightStateChange {
     pub colormode: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// Details about a specific light
 pub struct Light {
     /// The unique name given to the light


### PR DESCRIPTION
Hello ! 

First, thanks a lot for you work on this library, it's very useful ! :-) 
Disclaimer, I'm playing with Rust only for a couple of days so I'm a very very beginner. I hope my request is not too silly. 

I'm trying to code a little IHM with Rocket along with your lib. I have trouble to convert the `Light` structure into something compatible with  the`Template::render()` function of Rocket. I noticed that the `Light` structure does not implement  the `Serialize` trait. I just added it and now I can directly use the `Light` structure in the template rendering. 

Maybe there is a reason not to implement it but I'm too new in Rust to understand the side effects.

Best, 
Matthieu.