### PR TITLE
Support specifying transition times

### DIFF
--- a/src/hue.rs
+++ b/src/hue.rs
@@ -113,6 +113,9 @@ pub struct LightCommand {
     /// If "colorloop", the light will cycle hues
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effect: Option<String>,
+    /// The duration of the transition from the light’s current state to the new state. This is given as a multiple of 100ms and defaults to 4 (400ms).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transitiontime: Option<u16>,
     /// Has to be a value between -254 and 254. Increments or decrements the value of the brightness.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bri_inc: Option<i16>,
@@ -166,6 +169,10 @@ impl LightCommand {
     /// Sets the effect mode to set the light to
     pub fn with_effect(self, a: String) -> Self {
         LightCommand { effect: Some(a), ..self }
+    }
+    /// Sets the transition time
+    pub fn with_transitiontime(self, a: u16) -> Self {
+        LightCommand { transitiontime: Some(a), ..self }
     }
     /// Sets the brightness increment value
     pub fn with_bri_inc(self, b: i16) -> Self {


### PR DESCRIPTION
This adds support for specifying transition times in the `LightCommand` struct. It matches the spelling style in the [Hue API](https://developers.meethue.com/develop/hue-api/lights-api/#set-light-state), like the rest of the library follows.